### PR TITLE
Refactoring: Extrair constante

### DIFF
--- a/src/calc.ts
+++ b/src/calc.ts
@@ -10,6 +10,8 @@ const table_2022: Table = [
     [4664.68, Infinity, 27.50]
 ]
 
+const porcentage_value = 100;
+
 function sum(list: number[]): number {
     return list.reduce((acc, value) => acc + value, 0)
 }
@@ -31,7 +33,7 @@ function calculateBaseValuePerRange(baseValue: number, table: Table) {
 }
 
 function calculateIRPFTaxPerRange(baseValues: number[], table: Table): number[] {
-    return baseValues.map((value, i) => value * (table[i][2] / 100))
+    return baseValues.map((value, i) => value * (table[i][2] / porcentage_value))
 }
 
 function calculateTotalRangeBaseValues(baseValues: number[]): number {


### PR DESCRIPTION
Mau-cheiro: Uso de variável local
Descrição da refatoração: Foi utilizada a operação de refatoração Extrair Constante para remover uma variável que estava com valor fixo dentro do método calculateIRPFTaxPerRange Classes/métodos/atributos afetados: O método calculateIRPFTaxPerRange foi afetado recebendo a uma variável global, no local de constante fixa

Co-authored-by: JaimeJuan11 <jaime_ruan@hotmail.com>