### PR TITLE
Refactoring: substituir metodo p/ metodo obj

### DIFF
--- a/src/deductionsRegister.ts
+++ b/src/deductionsRegister.ts
@@ -1,4 +1,10 @@
-export interface IDeduction {
+interface DeductionResponse {
+  statusCode: number;
+  response: IDeduction[];
+  totalDeduction: number;
+}
+
+interface IDeduction {
   value: number;
   description: string;
 }
@@ -8,85 +14,86 @@ export interface IDependent {
   birthDate: Date;
 }
 
-const deductionlist: IDeduction[] = [];
-const dependentslist: IDependent[] = [];
-
-export interface DeductionResponse {
-  statusCode: number;
-  response: IDeduction[];
-  totalDeduction: number;
-}
-
-export function calculateDeductionTotals(deductionlist: IDeduction[]) {
-  try {
-    const totalDeduction = deductionlist.reduce(function (
-      accumulator,
-      deduction
-    ) {
-      return accumulator + deduction.value;
-    },
-    0);
-    return totalDeduction;
-  } catch (error) {
-    return error;
+export class Deduction {
+  deductionlist: IDeduction[];
+  dependentslist: IDependent[];
+  
+  constructor() {
+    this.deductionlist = [];
+    this.dependentslist = [];
   }
-}
 
-export function createDeduction(deduction: IDeduction) {
-  try {
-    if (deduction.value < 0 || !deduction.value)
-      throw new Error("ValorDeducaoInvalidoException");
-    if (deduction.description === "" || !deduction.description)
-      throw new Error("DescricaoEmBrancoException");
+  createDeduction(deduction: IDeduction){
+    try {
+      if (deduction.value < 0 || !deduction.value)
+        throw new Error("ValorDeducaoInvalidoException");
+      if (deduction.description === "" || !deduction.description)
+        throw new Error("DescricaoEmBrancoException");
 
-    deductionlist.push(deduction);
-    const total = calculateDeductionTotals(deductionlist);
+      this.deductionlist.push(deduction);
+      const total = this.calculateDeductionTotals(this.deductionlist);
 
-    const res_data: DeductionResponse = {
-      statusCode: 200,
-      response: deductionlist,
-      totalDeduction: Number(total),
-    };
-    return res_data;
-  } catch (error) {
-    return {
-      statusCode: 400,
-      error: error,
-    };
+      const res_data = {
+        statusCode: 200,
+        response: this.deductionlist,
+        totalDeduction: Number(total),
+      };
+      
+      return res_data;
+    } catch (error: any) {
+      return {
+        statusCode: 400,
+        error: error,
+      };
+    }
   }
-}
 
-// 189,59
-export function addDependent(dependent: IDependent) {
-  try {
-    if (dependent.name === "" || !dependent.name)
-      throw new Error("NomeEmBrancoException");
-
-    dependentslist.push(dependent);
-
-    return {
-      statusCode: 200,
-      response: dependentslist,
-    };
-  } catch (error) {
-    return {
-      statusCode: 400,
-      error: error,
-    };
+  calculateDeductionTotals(deductionlist: IDeduction[]) {
+    try {
+      const totalDeduction = deductionlist.reduce(function (
+        accumulator,
+        deduction
+      ) {
+        return accumulator + deduction.value;
+      },
+      0);
+      return totalDeduction;
+    } catch (error) {
+      return error;
+    }
   }
-}
 
-export function addDependentsList(dependents: IDependent[]) {
-  try {
-    dependents.forEach((item) => {
-      addDependent(item);
-    })
+  addDependent(dependent: IDependent) {
+    try {
+      if (dependent.name === "" || !dependent.name)
+        throw new Error("NomeEmBrancoException");
+  
+      this.dependentslist.push(dependent);
+  
+      return {
+        statusCode: 200,
+        response: this.dependentslist,
+      };
+    } catch (error) {
+      return {
+        statusCode: 400,
+        error: error,
+      };
+    }
+  }
 
-    return {
-      statusCode: 200,
-      response: dependentslist,
-    };
-  } catch (error) {
-    return error;
+  addDependentsList(dependents: IDependent[]) {
+    try {
+      dependents.forEach((item) => {
+        this.addDependent(item);
+      })
+  
+      return {
+        statusCode: 200,
+        response: this.dependentslist,
+      };
+    } catch (error) {
+      return error;
+    }
   }
 }

--- a/test/functional/irpf.test.ts
+++ b/test/functional/irpf.test.ts
@@ -9,14 +9,7 @@ import {
 import { effectiveRate } from '@src/effec';
 import request from "supertest";
 import { IIncome, registerIncome, calculateIncomeTotals } from '@src/incomesRegister';
-import {
-  createDeduction,
-  IDeduction,
-  calculateDeductionTotals,
-  IDependent,
-  addDependent,
-  addDependentsList,
-} from "@src/deductionsRegister";
+import { Deduction, IDependent } from '@src/deductionsRegister';
 
 describe('Income tests', () => {
   test('Should create income by falsificate data', () => {
@@ -156,7 +149,9 @@ describe("Register deductions test", () => {
   ])("Should register one or more deductions", (deductions, expected) => {
     let totalDeduction = 0;
     deductions.map((deduction) => {
-      const res: any = createDeduction(deduction);
+      var deduct_obj = new Deduction()
+
+      const res: any = deduct_obj.createDeduction(deduction);
       expect(res.statusCode).toEqual(res.statusCode);
       const lastdeduction = res.response.pop();
       expect(lastdeduction).toEqual(deduction);
@@ -172,7 +167,8 @@ describe('Should throw exception', () => {
     [{value: 1000, description: ""}, 'Error: DescricaoEmBrancoException'],
     [{value: Number(null), description: "Despesas com educacao"}, 'Error: ValorDeducaoInvalidoException']
   ])('Throw any exception', (deduction, exception) =>{
-      const res: any = createDeduction(deduction);
+      var deduct_obj = new Deduction();
+      const res: any = deduct_obj.createDeduction(deduction);
       expect(res.statusCode).toEqual(400);
       const res_error = (res.error).toString();
       expect(res_error).toEqual(exception);
@@ -202,8 +198,9 @@ describe("Dependent addition test", () => {
     ],
     [{}],
   ])("Should add one or many dependents", (dependents) => {
+    var deduct_obj = new Deduction();
     if (dependents?.hasOwnProperty("length")) {
-      const res: any = addDependentsList(dependents as IDependent[]);
+      const res: any = deduct_obj.addDependentsList(dependents as IDependent[]);
 
       expect(res?.statusCode).toEqual(200);
       expect(
@@ -216,7 +213,7 @@ describe("Dependent addition test", () => {
       return;
     }
 
-    const res: any = addDependent(dependents as IDependent);
+    const res: any = deduct_obj.addDependent(dependents as IDependent);
 
     // @ts-ignore
     if (!dependents?.name) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
         "noImplicitReturns": true,
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
+        "strictPropertyInitialization": false,
         "baseUrl": ".",
         "paths": {
             "@src/*": [


### PR DESCRIPTION
Mau(s) cheiro(s) identificado(s): variaveis locais entrelacadas Descrição da refatoração: Foi criado uma nova classe Deduction responsavel por realizar o createDeduction atraves de um metodo, dessa forma o metodo create deduction passou a ser um metodo de objeto da classe Deduction Classes/métodos/atributos afetados: Foi criada a classe Deduction, os metodos createDeduction, calculateDeductionTotals, addDependent e addDependentsList passaram se tornar metodos dessa classe, os testes referentes a deducoes agora chamam os metodos por meio de um obj deduction

Co-authored-by: Arthur Sena <senaarth@gmail.com>